### PR TITLE
Parallel BVH creation using rayon

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,9 @@ documentation = "https://docs.rs/crate/bvh2d"
 license = "MIT"
 
 [dependencies]
+bevy = { version = "0.9.1", default-features = false, features = [], optional = true }
 glam = "0.22"
+rayon = { version = "1.6.1", optional = true }
+
+[features]
+default = ["rayon"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ documentation = "https://docs.rs/crate/bvh2d"
 license = "MIT"
 
 [dependencies]
-bevy = { version = "0.9.1", default-features = false, features = [], optional = true }
 glam = "0.22"
 rayon = { version = "1.6.1", optional = true }
 

--- a/src/aabb.rs
+++ b/src/aabb.rs
@@ -1,4 +1,5 @@
 use std::f32;
+use std::fmt::Display;
 
 use crate::{Point2, Vector2};
 
@@ -9,6 +10,12 @@ use crate::axis::Axis;
 pub struct AABB {
     pub min: Point2,
     pub max: Point2,
+}
+
+impl Display for AABB {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "min bound: {}; max bound: {}", self.min, self.max)
+    }
 }
 
 pub trait Bounded {
@@ -76,5 +83,17 @@ impl AABB {
         } else {
             Axis::Y
         }
+    }
+
+    pub(crate) fn approx_contains_eps(&self, p: &Point2, epsilon: f32) -> bool {
+        (p.x - self.min.x) > -epsilon
+            && (p.x - self.max.x) < epsilon
+            && (p.y - self.min.y) > -epsilon
+            && (p.y - self.max.y) < epsilon
+    }
+
+    pub fn approx_contains_aabb_eps(&self, other: &AABB, epsilon: f32) -> bool {
+        self.approx_contains_eps(&other.min, epsilon)
+            && self.approx_contains_eps(&other.max, epsilon)
     }
 }

--- a/src/bvh2d/bvh2d_impl.rs
+++ b/src/bvh2d/bvh2d_impl.rs
@@ -120,7 +120,9 @@ impl BVH2dNode {
             return;
         }
 
+        #[allow(unused_mut)]
         let mut parallel_recurse = false;
+        #[cfg(feature = "rayon")]
         if indices.len() > 64 {
             parallel_recurse = true;
         }
@@ -152,38 +154,38 @@ impl BVH2dNode {
 
             // Proceed recursively.
             if parallel_recurse {
-                let (shapes_a, shapes_b) = unsafe {
-                    let ptr = shapes.as_mut_ptr();
-                    let len = shapes.len();
-                    let shapes_a = std::slice::from_raw_parts_mut(ptr, len);
-                    let shapes_b = std::slice::from_raw_parts_mut(ptr, len);
-                    (shapes_a, shapes_b)
-                };
+                // parallel_recurse is only ever true when the rayon feature is enabled
+                #[cfg(feature = "rayon")]
+                {
+                    let (shapes_a, shapes_b) = unsafe {
+                        let ptr = shapes.as_mut_ptr();
+                        let len = shapes.len();
+                        let shapes_a = std::slice::from_raw_parts_mut(ptr, len);
+                        let shapes_b = std::slice::from_raw_parts_mut(ptr, len);
+                        (shapes_a, shapes_b)
+                    };
 
-                #[cfg(all(feature="rayon", not(feature="bevy")))]
-                rayon::join(
-                    || {
-                        BVH2dNode::build(
-                            shapes_a,
-                            child_l_indices,
-                            l_nodes,
-                            child_l_index,
-                            node_index,
-                        )
-                    },
-                    || {
-                        BVH2dNode::build(
-                            shapes_b,
-                            child_r_indices,
-                            r_nodes,
-                            child_r_index,
-                            node_index,
-                        )
-                    },
-                );
-
-                #[cfg(all(feature="bevy", not(feature="rayon")))]
-                todo!()
+                    rayon::join(
+                        || {
+                            BVH2dNode::build(
+                                shapes_a,
+                                child_l_indices,
+                                l_nodes,
+                                child_l_index,
+                                node_index,
+                            )
+                        },
+                        || {
+                            BVH2dNode::build(
+                                shapes_b,
+                                child_r_indices,
+                                r_nodes,
+                                child_r_index,
+                                node_index,
+                            )
+                        },
+                    );
+                }
             } else {
                 BVH2dNode::build(shapes, child_l_indices, l_nodes, child_l_index, node_index);
                 BVH2dNode::build(shapes, child_r_indices, r_nodes, child_r_index, node_index);
@@ -274,39 +276,38 @@ impl BVH2dNode {
 
             // Proceed recursively.
             if parallel_recurse {
-                // parallel split
-                let (shapes_a, shapes_b) = unsafe {
-                    let ptr = shapes.as_mut_ptr();
-                    let len = shapes.len();
-                    let shapes_a = std::slice::from_raw_parts_mut(ptr, len);
-                    let shapes_b = std::slice::from_raw_parts_mut(ptr, len);
-                    (shapes_a, shapes_b)
-                };
+                // parallel_recurse is only ever true when the rayon feature is enabled
+                #[cfg(feature = "rayon")]
+                {
+                    let (shapes_a, shapes_b) = unsafe {
+                        let ptr = shapes.as_mut_ptr();
+                        let len = shapes.len();
+                        let shapes_a = std::slice::from_raw_parts_mut(ptr, len);
+                        let shapes_b = std::slice::from_raw_parts_mut(ptr, len);
+                        (shapes_a, shapes_b)
+                    };
 
-                #[cfg(all(feature="rayon", not(feature="bevy")))]
-                rayon::join(
-                    || {
-                        BVH2dNode::build(
-                            shapes_a,
-                            child_l_indices,
-                            l_nodes,
-                            child_l_index,
-                            node_index,
-                        )
-                    },
-                    || {
-                        BVH2dNode::build(
-                            shapes_b,
-                            child_r_indices,
-                            r_nodes,
-                            child_r_index,
-                            node_index,
-                        )
-                    },
-                );
-
-                #[cfg(all(feature="bevy", not(feature="rayon")))]
-                todo!()
+                    rayon::join(
+                        || {
+                            BVH2dNode::build(
+                                shapes_a,
+                                child_l_indices,
+                                l_nodes,
+                                child_l_index,
+                                node_index,
+                            )
+                        },
+                        || {
+                            BVH2dNode::build(
+                                shapes_b,
+                                child_r_indices,
+                                r_nodes,
+                                child_r_index,
+                                node_index,
+                            )
+                        },
+                    );
+                }
             } else {
                 BVH2dNode::build(shapes, child_l_indices, l_nodes, child_l_index, node_index);
                 BVH2dNode::build(shapes, child_r_indices, r_nodes, child_r_index, node_index);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,7 @@
 use crate::aabb::{Bounded, AABB};
 
 #[inline]
+#[allow(unused)]
 pub fn concatenate_vectors<T: Sized>(vectors: &mut [Vec<T>]) -> Vec<T> {
     let mut result = Vec::with_capacity(vectors.iter().map(|v| v.len()).sum());
     for vector in vectors.iter_mut() {


### PR DESCRIPTION
This is essentially just a port of the parallel bvh creation from https://github.com/svenstaro/bvh/pull/80
Most of the added code outside the build functions was added for testing, with the main changes being the build functions being rewritten to work on mutable slices of indices instead of recursively passing back an index.

Based on the polyanya baking bench, this is about 10% faster singlethreaded (with the rayon feature disabled, ~9.4ms main -> 8.4ms pr), or about 60% faster when multithreaded (~9.4ms main -> ~3.5ms pr). Even with a single thread rayon taskpool it's still faster than main (~8.9ms), and gets faster up until 4-5 threads on my machine, at which point gains become tiny, then non existent (2Threads: ~5.5ms, 4T: ~3.8ms, 6T: ~3.4ms, 8T: ~3.4ms)

I had a bevy tasks implementation as well, but it was quite a bit slower than the single threaded version so I didn't bother with it.